### PR TITLE
fix rust issues with .stupyder being hardcoded to append to each file

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,25 @@ local default_config = {
         }
       }
     },
+    rust = {
+      contexts = {
+        command_context = {
+          ext = ".rs",
+          cmd = {
+            "rustc {code_file} -o out_rs",
+            "./out_rs",
+          },
+          remove_files = { "out_rs" },
+          cwd = "{tmpdir}/stupyder/rust",
+        }
+      }
+    },
     c = {
       contexts = {
         command_context = {
           ext =".c",
           cmd = { "gcc {code_file} -o out.bin", "./out.bin" },
-          -- list of files to remove
+          -- list of files excluding the code file to remove
           remove_files = { "out.bin" },
           -- change where the command(s) are executed, default is pwd
           cwd = "{tmpdir}/stupyder/c"
@@ -194,5 +207,10 @@ local default_config = {
   contexts = {
     -- Default settings, you can add cwd, filename, etc
     default = {},
+    command_context = {
+      -- This is appended onto each code file created with the command context ie test.c is test_stupyder.c
+      -- to remove set to ""
+      stupyder_file_id = "_stupyder"
+    }
   },
 }

--- a/lua/stupyder/config.lua
+++ b/lua/stupyder/config.lua
@@ -22,6 +22,19 @@ local default_config = {
                 }
             }
         },
+        rust = {
+            contexts = {
+                command_context = {
+                    ext = ".rs",
+                    cmd = {
+                        "rustc {code_file} -o out_rs",
+                        "./out_rs",
+                    },
+                    remove_files = { "out_rs" },
+                    cwd = "{tmpdir}/stupyder/rust",
+                }
+            }
+        },
         c = {
             contexts = {
                 command_context = {
@@ -63,6 +76,11 @@ local default_config = {
     },
     contexts = {
         default = {},
+        command_context = {
+            -- This is appended onto each code file created with the command context
+            -- to remove set to ""
+            stupyder_file_id = "_stupyder"
+        }
     },
 }
 

--- a/spec/contexts/command_context_spec.lua
+++ b/spec/contexts/command_context_spec.lua
@@ -31,11 +31,58 @@ describe("Command Context Tests", function ()
     assert.falsy(err)
     assert.spy(file_mock.write).was.called_with(file_mock, "somewords")
 
-    local expected = { filename="heythere.stupyder.c", path = "/tmp/heythere.stupyder.c" }
+    local expected = { filename="heythere.c", path = "/tmp/heythere.c" }
     for k, _ in pairs(out) do
       assert.equal(expected[k], out[k])
     end
   end)
+
+  it("Creates a file correctly with a stupyder id", function ()
+    moc(utils, "generateRandomString", function() return "heythere" end, spy, finally)
+
+    local file_mock = {
+      write = function() end,
+      close = function() end
+    }
+    spy.on(file_mock, "write")
+    spy.on(file_mock, "close")
+
+    moc(io, "open", function() return file_mock end, spy, finally)
+
+    local out, err = ccontext:_create_file("somewords", { ext = ".c", stupyder_file_id = "_stupyder" }, "/tmp")
+
+    assert.falsy(err)
+    assert.spy(file_mock.write).was.called_with(file_mock, "somewords")
+
+    local expected = { filename="heythere_stupyder.c", path = "/tmp/heythere_stupyder.c" }
+    for k, _ in pairs(out) do
+      assert.equal(expected[k], out[k])
+    end
+  end)
+
+  it("Creates a file correctly with a filename set", function ()
+    moc(utils, "generateRandomString", function() return "heythere" end, spy, finally)
+
+    local file_mock = {
+      write = function() end,
+      close = function() end
+    }
+    spy.on(file_mock, "write")
+    spy.on(file_mock, "close")
+
+    moc(io, "open", function() return file_mock end, spy, finally)
+
+    local out, err = ccontext:_create_file("somewords", { ext = ".c", filename = "testfile" }, "/tmp")
+
+    assert.falsy(err)
+    assert.spy(file_mock.write).was.called_with(file_mock, "somewords")
+
+    local expected = { filename="testfile.c", path = "/tmp/testfile.c" }
+    for k, _ in pairs(out) do
+      assert.equal(expected[k], out[k])
+    end
+  end)
+
 
   local cwd_tests = {
     {

--- a/test.md
+++ b/test.md
@@ -8,6 +8,18 @@ A bunch of simple code snippets in different languages to test Stupyder.nvim
 print("hello, world")
 ```
 
+### Rust example
+```rust
+// This is the main function.
+fn main() {
+    // Statements here are executed when the compiled binary is called.
+
+    // Print text to the console.
+    println!("Hello World!");
+}
+
+```
+
 ### Demo to show incremental output working
 ```python
 import time
@@ -23,6 +35,7 @@ for i in range(0, 3):
 echo "ahhhh" >> somefile
 cat somefile
 ```
+
 
 ### Lua example + theme change
 ```lua


### PR DESCRIPTION
This should fix #1 

We hardcoded .stupyder as an identifier. I made this _stupyder by default and configurable. I could probably just get rid of that altogether since we remove the file by default. 
<img width="1196" height="274" alt="2025-08-06-222805_hyprshot" src="https://github.com/user-attachments/assets/b35bb36c-618f-410b-9f60-beae4e5df187" />
